### PR TITLE
Allow conditionally sanitizing anchor tags

### DIFF
--- a/lib/DangerousHTML.js
+++ b/lib/DangerousHTML.js
@@ -59,6 +59,8 @@ DangerousHTML = function (_React$Component) {_inherits(DangerousHTML, _React$Com
 
 
 
+
+
     state = {
       canRenderHTML: true }, _this.
 
@@ -120,7 +122,7 @@ DangerousHTML = function (_React$Component) {_inherits(DangerousHTML, _React$Com
     } }, { key: 'prepareAnchors', value: function prepareAnchors()
 
     {
-      if (!this.element) {
+      if (!this.element || !this.props.sanitizeAnchor) {
         return;
       }
 
@@ -148,8 +150,7 @@ DangerousHTML = function (_React$Component) {_inherits(DangerousHTML, _React$Com
           dangerouslySetInnerHTML: { __html: html } }));
 
 
-    } }]);return DangerousHTML;}(_react2.default.Component);DangerousHTML.propTypes = { html: _propTypes2.default.string.isRequired, tagName: _propTypes2.default.string, className: _propTypes2.default.string };DangerousHTML.defaultProps = { tagName: 'div', className: '' };exports.default =
+    } }]);return DangerousHTML;}(_react2.default.Component);DangerousHTML.propTypes = { html: _propTypes2.default.string.isRequired, sanitizeAnchor: _propTypes2.default.bool, tagName: _propTypes2.default.string, className: _propTypes2.default.string };DangerousHTML.defaultProps = { tagName: 'div', className: '', sanitizeAnchor: true };exports.default =
 
 
 DangerousHTML;
-//# sourceMappingURL=DangerousHTML.js.map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dangerous-html",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DangerousHTML component that evaluates script tags",
   "keywords": [
     "react",

--- a/src/DangerousHTML.js
+++ b/src/DangerousHTML.js
@@ -50,13 +50,15 @@ function removeScriptElements(scriptElements) {
 class DangerousHTML extends React.Component {
   static propTypes = {
     html: PropTypes.string.isRequired,
+    sanitizeAnchor: PropTypes.bool,
     tagName: PropTypes.string,
     className: PropTypes.string
   };
 
   static defaultProps = {
     tagName: 'div',
-    className: ''
+    className: '',
+    sanitizeAnchor: true,
   };
 
   state = {
@@ -120,7 +122,7 @@ class DangerousHTML extends React.Component {
   }
 
   prepareAnchors() {
-    if (!this.element) {
+    if (!this.element || !this.props.sanitizeAnchor) {
       return;
     }
 


### PR DESCRIPTION
Forcefully making all links to open in new tab is a little bit invasive for a generic purpose component like this. I have added a new prop that can turn this off while still maintaining the current behaviour by default. Would be super happy if you accepted this contribution to the package. 
Also, thank you for making this package.